### PR TITLE
Timestamp unreliable messages.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ autoexamples = false
 name = "mvp"
 
 [dependencies]
-carrier-pigeon = { git = "https://github.com/mitchellmarinodev/carrier-pigeon", rev = "e4216576b67685153b3b058920c6bf0498687632" }
+carrier-pigeon = { git = "https://github.com/mitchellmarinodev/carrier-pigeon", rev = "46d275f5ab34c0656141221b924df71fd3f510b7" }
 bevy = "~0.7.0"
 serde = { version = "~1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ autoexamples = false
 name = "mvp"
 
 [dependencies]
-carrier-pigeon = { git = "https://github.com/mitchellmarinodev/carrier-pigeon", rev = "46d275f5ab34c0656141221b924df71fd3f510b7" }
+carrier-pigeon = { git = "https://github.com/mitchellmarinodev/carrier-pigeon", rev = "70c365451fddb7de3dc4d3c856e9b3afdf014680" }
 bevy = "~0.7.0"
 serde = { version = "~1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bevy-pigeon
 
-The bevy plugin for `carrier-pigeon`.
+The bevy plugin for [`carrier-pigeon`](https://github.com/MitchellMarinoDev/carrier-pigeon).
 
 Building on `carrier-pigeon`, this crate provides high level network abstractions to allow making a game a breeze.
 `bevy-pigeon` takes care of most of the networking for you, so you barely have to see it or think about it.
@@ -16,8 +16,9 @@ Building on `carrier-pigeon`, this crate provides high level network abstraction
 
 ## Is bevy-pigeon right for me?
 
-Since carrier-pigeon uses TCP and UDP, it is usable and convenient for most all games. since bevy-pigeon only adds
-features, you have access to higher level features, but you can still just send raw carrier-pigeon messages.
+Since carrier-pigeon uses TCP and UDP, it is usable and convenient for most all games. FPS games (and other games where
+precise position is of the upmost importance) would benefit from a backroll solution like [bevy_backroll](https://crates.io/crates/bevy_backroll)
+or [bevy_ggrs](https://github.com/gschup/bevy_ggrs). Though, it is possible to make an FPS with `bevy-pigeon`
 
 TCP is required for the connection cycle in carrier-pigeon, so if you want to target wasm, pigeon will not work for you.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Building on `carrier-pigeon`, this crate provides high level network abstraction
 
 Since carrier-pigeon uses TCP and UDP, it is usable and convenient for most all games. FPS games (and other games where
 precise position is of the upmost importance) would benefit from a backroll solution like [bevy_backroll](https://crates.io/crates/bevy_backroll)
-or [bevy_ggrs](https://github.com/gschup/bevy_ggrs). Though, it is possible to make an FPS with `bevy-pigeon`
+or [bevy_ggrs](https://github.com/gschup/bevy_ggrs). Though, it is certainly possible to make an FPS with `bevy-pigeon`
 
 TCP is required for the connection cycle in carrier-pigeon, so if you want to target wasm, pigeon will not work for you.
 
@@ -46,7 +46,7 @@ A quickstart guide that goes in more detail is found at [/Quickstart.md](Quickst
 
 ### Examples
 
-- A full 2-player pong/breakout game made with `bevy-pigeon` is available on [GitHub](https://github.com/MitchellMarinoDev/bong)
+- Bong: A full 2-player pong/breakout game made with `bevy-pigeon` is available on [GitHub](https://github.com/MitchellMarinoDev/bong)
 - Check out the 
 [`examples/` directory](examples).
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -223,5 +223,6 @@ fn get_latest_msg<'a, M: Any + Send + Sync>(msgs: &'a Vec<NetMsg<NetCompMsg<M>>>
             latest = Some(m);
         }
     }
+    println!("{}", latest_time);
     latest
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,11 @@
 //! The app extension.
 use crate::sync::{CNetDir, NetCompMsg, SNetDir};
 use bevy::prelude::*;
-use carrier_pigeon::{CId, Client, MsgRegError, MsgTable, Server, SortedMsgTable, Transport};
+use carrier_pigeon::{Client, MsgRegError, MsgTable, Server, SortedMsgTable, Transport};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::any::Any;
+use carrier_pigeon::net::{CIdSpec, NetMsg};
 use crate::sync::{NetComp, NetEntity};
 
 /// An extension trait for easy registering [`NetComp`] types.
@@ -165,21 +166,18 @@ fn comp_send<T, M>(
 fn comp_recv<T, M>(
     server: Option<ResMut<Server>>,
     client: Option<ResMut<Client>>,
-    mut q: Query<(&NetEntity, &NetComp<T, M>, &mut T)>,
+    mut q: Query<(&NetEntity, &mut NetComp<T, M>, &mut T)>,
 ) where
     T: Clone + Into<M> + Component,
     M: Clone + Into<T> + Any + Send + Sync,
 {
     if let Some(server) = server {
         // Cache messages
-        let msgs: Vec<(CId, &NetCompMsg<M>)> = server.recv::<NetCompMsg<M>>().unwrap().collect();
-        for (net_e, net_c, mut comp) in q.iter_mut() {
-            if let Some(from_spec) = net_c.s_dir.from() {
-                if let Some(&(_cid, valid_msg)) = msgs
-                    .iter()
-                    .filter(|(cid, msg)| from_spec.matches(*cid) && msg.id == net_e.id)
-                    .last()
-                {
+        let msgs: Vec<NetMsg<NetCompMsg<M>>> = server.recv::<NetCompMsg<M>>().unwrap().collect();
+        for (net_e, mut net_c, mut comp) in q.iter_mut() {
+            if let Some(&spec) = net_c.s_dir.from() {
+                if let Some(valid_msg) = get_latest_msg(&msgs, net_c.last, spec, net_e.id) {
+                    net_c.last = valid_msg.time;
                     *comp = valid_msg.msg.clone().into();
                 }
             }
@@ -191,14 +189,39 @@ fn comp_recv<T, M>(
             }
         }
     } else if let Some(client) = client {
-        let msgs: Vec<&NetCompMsg<M>> = client.recv::<NetCompMsg<M>>().unwrap().collect();
-        for (net_e, net_c, mut comp) in q.iter_mut() {
+        let msgs: Vec<NetMsg<NetCompMsg<M>>> = client.recv::<NetCompMsg<M>>().unwrap().collect();
+        for (net_e, mut net_c, mut comp) in q.iter_mut() {
             if net_c.c_dir == CNetDir::From {
-                // Get the last message that matches with the entity and CIdSpec
-                if let Some(&valid_msg) = msgs.iter().filter(|msg| msg.id == net_e.id).last() {
+                if let Some(valid_msg) = get_latest_msg(&msgs, net_c.last, CIdSpec::All, net_e.id) {
+                    net_c.last = valid_msg.time;
+                    *comp = valid_msg.msg.clone().into();
+                }
+
+
+                if let Some(valid_msg) = msgs.iter().filter(|msg| msg.id == net_e.id).last() {
                     *comp = valid_msg.msg.clone().into();
                 }
             }
         }
     }
+}
+
+/// Gets the most recent message that matches `from_spec` for entity with `id`
+/// if it is sent later that current.
+fn get_latest_msg<'a, M: Any + Send + Sync>(msgs: &'a Vec<NetMsg<NetCompMsg<M>>>, current: Option<u32>, spec: CIdSpec, id: u64) -> Option<&'a NetMsg<'a, NetCompMsg<M>>> {
+    let mut latest_time = current.unwrap_or(0);
+    let mut latest = None;
+    for m in msgs.iter().filter(|m| spec.matches(m.cid) && m.id == id) {
+        if let Some(time) = m.time {
+            // If this packet has a send time, get the last.
+            if time > latest_time {
+                latest_time = time;
+                latest = Some(m);
+            }
+        } else {
+            // If this does not have a send time, just get the last one received.
+            latest = Some(m);
+        }
+    }
+    latest
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use bevy::prelude::*;
 mod app;
 pub mod sync;
 mod tick;
+mod types;
 
 pub use app::AppExt;
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -18,6 +18,8 @@ where
     /// If enabled, this only sends a message if the component changed.
     /// This uses bevy's change detection, which may detect false positives.
     pub cd: bool,
+    /// The timestamp of the last message received and written to this component.
+    pub last: Option<u32>,
     /// The net direction for the client.
     pub c_dir: CNetDir,
     /// The net direction for the server.
@@ -33,6 +35,7 @@ where
     fn default() -> Self {
         NetComp {
             cd: true,
+            last: None,
             c_dir: CNetDir::From,
             s_dir: SNetDir::To(CIdSpec::All),
             _pd: PhantomData,
@@ -50,6 +53,7 @@ where
     pub fn new(c_dir: CNetDir, s_dir: SNetDir) -> Self {
         NetComp {
             cd: true,
+            last: None,
             c_dir,
             s_dir,
             _pd: PhantomData,

--- a/src/types/light.rs
+++ b/src/types/light.rs
@@ -1,0 +1,121 @@
+//! Types in this file:
+//!  - [AmbientLight]
+//!  - [DirectionalLight]
+//!  - [PointLight]
+
+use serde::{Serialize, Deserialize};
+use bevy::reflect::FromReflect;
+use bevy::prelude::*;
+use crate::types::misc::NetOrthographicProjection;
+
+/// The network-able version of [AmbientLight].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
+#[reflect(PartialEq, Serialize, Deserialize)]
+pub struct NetAmbientLight {
+    pub color: Color,
+    /// A direct scale factor multiplied with `color` before being passed to the shader.
+    pub brightness: f32,
+}
+
+impl From<AmbientLight> for NetAmbientLight {
+    fn from(o: AmbientLight) -> Self {
+        NetAmbientLight {
+            color: o.color,
+            brightness: o.brightness,
+        }
+    }
+}
+
+impl From<NetAmbientLight> for AmbientLight {
+    fn from(o: NetAmbientLight) -> Self {
+        AmbientLight {
+            color: o.color,
+            brightness: o.brightness,
+        }
+    }
+}
+
+/// The network-able version of [DirectionalLight].
+#[derive(Debug, Clone, Serialize, Deserialize, Reflect)]
+#[reflect(Serialize, Deserialize)]
+pub struct NetDirectionalLight {
+    pub color: Color,
+    /// Illuminance in lux
+    pub illuminance: f32,
+    pub shadows_enabled: bool,
+    pub shadow_projection: NetOrthographicProjection,
+    pub shadow_depth_bias: f32,
+    /// A bias applied along the direction of the fragment's surface normal. It is scaled to the
+    /// shadow map's texel size so that it is automatically adjusted to the orthographic projection.
+    pub shadow_normal_bias: f32,
+}
+
+impl From<DirectionalLight> for NetDirectionalLight {
+    fn from(o: DirectionalLight) -> Self {
+        NetDirectionalLight {
+            color: o.color,
+            illuminance: o.illuminance,
+            shadows_enabled: o.shadows_enabled,
+            shadow_projection: o.shadow_projection.into(),
+            shadow_depth_bias: o.shadow_depth_bias,
+            shadow_normal_bias: o.shadow_normal_bias,
+        }
+    }
+}
+
+impl From<NetDirectionalLight> for DirectionalLight {
+    fn from(o: NetDirectionalLight) -> Self {
+        DirectionalLight {
+            color: o.color,
+            illuminance: o.illuminance,
+            shadows_enabled: o.shadows_enabled,
+            shadow_projection: o.shadow_projection.into(),
+            shadow_depth_bias: o.shadow_depth_bias,
+            shadow_normal_bias: o.shadow_normal_bias,
+        }
+    }
+}
+
+/// The network-able version of [PointLight].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
+#[reflect(PartialEq, Serialize, Deserialize)]
+pub struct NetPointLight {
+    pub color: Color,
+    pub intensity: f32,
+    pub range: f32,
+    pub radius: f32,
+    pub shadows_enabled: bool,
+    pub shadow_depth_bias: f32,
+    /// A bias applied along the direction of the fragment's surface normal. It is scaled to the
+    /// shadow map's texel size so that it can be small close to the camera and gets larger further
+    /// away.
+    pub shadow_normal_bias: f32,
+}
+
+impl From<PointLight> for NetPointLight {
+    fn from(o: PointLight) -> Self {
+        NetPointLight {
+            color: o.color,
+            intensity: o.intensity,
+            range: o.range,
+            radius: o.radius,
+            shadows_enabled: o.shadows_enabled,
+            shadow_depth_bias: o.shadow_depth_bias,
+            shadow_normal_bias: o.shadow_normal_bias,
+        }
+    }
+}
+
+impl From<NetPointLight> for PointLight {
+    fn from(o: NetPointLight) -> Self {
+        PointLight {
+            color: o.color,
+            intensity: o.intensity,
+            range: o.range,
+            radius: o.radius,
+            shadows_enabled: o.shadows_enabled,
+            shadow_depth_bias: o.shadow_depth_bias,
+            shadow_normal_bias: o.shadow_normal_bias,
+        }
+    }
+}

--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -1,0 +1,247 @@
+#![allow(deprecated)]
+
+//! Types in this file:
+//! - [Transform]
+//! - [OrthographicProjection]
+//! - [Name]
+//! - [Visibility]
+//! - [AlphaMode]
+//! - [EulerRot]
+
+use serde::{Serialize, Deserialize};
+use bevy::reflect::FromReflect;
+use bevy::prelude::*;
+use bevy::render::camera::{DepthCalculation, ScalingMode, WindowOrigin};
+
+/// The network-able version of [Transform].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
+#[reflect(PartialEq, Serialize, Deserialize)]
+pub struct NetTransform {
+    /// Position of the entity. In 2d, the last value of the `Vec3` is used for z-ordering.
+    pub translation: Vec3,
+    /// Rotation of the entity.
+    pub rotation: Quat,
+    /// Scale of the entity.
+    pub scale: Vec3,
+}
+
+impl From<Transform> for NetTransform {
+    fn from(o: Transform) -> Self {
+        NetTransform {
+            translation: o.translation,
+            rotation: o.rotation,
+            scale: o.scale,
+        }
+    }
+}
+
+impl From<NetTransform> for Transform {
+    fn from(o: NetTransform) -> Self {
+        Transform {
+            translation: o.translation,
+            rotation: o.rotation,
+            scale: o.scale,
+        }
+    }
+}
+
+/// The network-able version of [OrthographicProjection].
+#[derive(Debug, Clone, Serialize, Deserialize, Reflect)]
+#[reflect(Serialize, Deserialize)]
+pub struct NetOrthographicProjection {
+    pub left: f32,
+    pub right: f32,
+    pub bottom: f32,
+    pub top: f32,
+    pub near: f32,
+    pub far: f32,
+    pub window_origin: WindowOrigin,
+    pub scaling_mode: ScalingMode,
+    pub scale: f32,
+    pub depth_calculation: DepthCalculation,
+}
+
+impl From<OrthographicProjection> for NetOrthographicProjection {
+    fn from(o: OrthographicProjection) -> Self {
+        NetOrthographicProjection {
+            left: o.left,
+            right: o.right,
+            bottom: o.bottom,
+            top: o.top,
+            near: o.near,
+            far: o.far,
+            window_origin: o.window_origin,
+            scaling_mode: o.scaling_mode,
+            scale: o.scale,
+            depth_calculation: o.depth_calculation,
+        }
+    }
+}
+
+impl From<NetOrthographicProjection> for OrthographicProjection {
+    fn from(o: NetOrthographicProjection) -> Self {
+        OrthographicProjection {
+            left: o.left,
+            right: o.right,
+            bottom: o.bottom,
+            top: o.top,
+            near: o.near,
+            far: o.far,
+            window_origin: o.window_origin,
+            scaling_mode: o.scaling_mode,
+            scale: o.scale,
+            depth_calculation: o.depth_calculation,
+        }
+    }
+}
+
+/// The network-able version of [Name].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
+#[reflect(PartialEq, Serialize, Deserialize)]
+pub struct NetName {
+    pub name: String,
+}
+
+impl From<Name> for NetName {
+    fn from(o: Name) -> Self {
+        NetName {
+            name: o.as_str().into()
+        }
+    }
+}
+
+impl From<NetName> for Name {
+    fn from(o: NetName) -> Self {
+        Name::new(o.name)
+    }
+}
+
+/// The network-able version of [Visibility].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
+#[reflect(PartialEq, Serialize, Deserialize)]
+pub struct NetVisibility {
+    pub is_visible: bool,
+}
+
+impl From<Visibility> for NetVisibility {
+    fn from(o: Visibility) -> Self {
+        NetVisibility {
+            is_visible: o.is_visible,
+        }
+    }
+}
+
+impl From<NetVisibility> for Visibility {
+    fn from(o: NetVisibility) -> Self {
+        Visibility {
+            is_visible: o.is_visible,
+        }
+    }
+}
+
+/// The network-able version of [AlphaMode].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
+#[reflect(PartialEq, Serialize, Deserialize)]
+pub enum NetAlphaMode {
+    Opaque,
+    /// An alpha cutoff must be supplied where alpha values >= the cutoff
+    /// will be fully opaque and < will be fully transparent
+    Mask(f32),
+    Blend,
+}
+
+impl From<AlphaMode> for NetAlphaMode {
+    fn from(o: AlphaMode) -> Self {
+        match o {
+            AlphaMode::Opaque => NetAlphaMode::Opaque,
+            AlphaMode::Mask(v) => NetAlphaMode::Mask(v),
+            AlphaMode::Blend => NetAlphaMode::Blend,
+        }
+    }
+}
+
+impl From<NetAlphaMode> for AlphaMode {
+    fn from(o: NetAlphaMode) -> Self {
+        match o {
+            NetAlphaMode::Opaque => AlphaMode::Opaque,
+            NetAlphaMode::Mask(v) => AlphaMode::Mask(v),
+            NetAlphaMode::Blend => AlphaMode::Blend,
+        }
+    }
+}
+
+/// The network-able version of [EulerRot].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
+#[reflect(PartialEq, Serialize, Deserialize)]
+pub enum NetEulerRot {
+    /// Intrinsic three-axis rotation ZYX
+    ZYX,
+    /// Intrinsic three-axis rotation ZXY
+    ZXY,
+    /// Intrinsic three-axis rotation YXZ
+    YXZ,
+    /// Intrinsic three-axis rotation YZX
+    YZX,
+    /// Intrinsic three-axis rotation XYZ
+    XYZ,
+    /// Intrinsic three-axis rotation XZY
+    XZY,
+    /// Intrinsic two-axis rotation ZYZ
+    #[deprecated(note = "Untested! Use at own risk!")]
+    ZYZ,
+    /// Intrinsic two-axis rotation ZXZ
+    #[deprecated(note = "Untested! Use at own risk!")]
+    ZXZ,
+    /// Intrinsic two-axis rotation YXY
+    #[deprecated(note = "Untested! Use at own risk!")]
+    YXY,
+    /// Intrinsic two-axis rotation YZY
+    #[deprecated(note = "Untested! Use at own risk!")]
+    YZY,
+    /// Intrinsic two-axis rotation XYX
+    #[deprecated(note = "Untested! Use at own risk!")]
+    XYX,
+    /// Intrinsic two-axis rotation XZX
+    #[deprecated(note = "Untested! Use at own risk!")]
+    XZX,
+}
+
+impl From<EulerRot> for NetEulerRot {
+    fn from(o: EulerRot) -> Self {
+        match o {
+            EulerRot::ZYX => NetEulerRot::ZYX,
+            EulerRot::ZXY => NetEulerRot::ZXY,
+            EulerRot::YXZ => NetEulerRot::YXZ,
+            EulerRot::YZX => NetEulerRot::YZX,
+            EulerRot::XYZ => NetEulerRot::XYZ,
+            EulerRot::XZY => NetEulerRot::XZY,
+
+            EulerRot::ZYZ => NetEulerRot::ZYZ,
+            EulerRot::ZXZ => NetEulerRot::ZXZ,
+            EulerRot::YXY => NetEulerRot::YXY,
+            EulerRot::YZY => NetEulerRot::YZY,
+            EulerRot::XYX => NetEulerRot::XYX,
+            EulerRot::XZX => NetEulerRot::XZX,
+        }
+    }
+}
+
+impl From<NetEulerRot> for EulerRot {
+    fn from(o: NetEulerRot) -> Self {
+        match o {
+            NetEulerRot::ZYX => EulerRot::ZYX,
+            NetEulerRot::ZXY => EulerRot::ZXY,
+            NetEulerRot::YXZ => EulerRot::YXZ,
+            NetEulerRot::YZX => EulerRot::YZX,
+            NetEulerRot::XYZ => EulerRot::XYZ,
+            NetEulerRot::XZY => EulerRot::XZY,
+
+            NetEulerRot::ZYZ => EulerRot::ZYZ,
+            NetEulerRot::ZXZ => EulerRot::ZXZ,
+            NetEulerRot::YXY => EulerRot::YXY,
+            NetEulerRot::YZY => EulerRot::YZY,
+            NetEulerRot::XYX => EulerRot::XYX,
+            NetEulerRot::XZX => EulerRot::XZX,
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,30 @@
+//! Provides network-able types for common bevy types.
+
+use bevy::prelude::*;
+
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Debug)]
+pub struct NetTransform {
+    pub translation: Vec3,
+    pub rotation: Quat,
+    pub scale: Vec3,
+}
+
+impl From<Transform> for NetTransform {
+    fn from(o: Transform) -> Self {
+        MyTransform {
+            translation: o.translation,
+            rotation: o.rotation,
+            scale: o.scale,
+        }
+    }
+}
+
+impl From<NetTransform> for Transform {
+    fn from(o: MyTransform) -> Self {
+        Transform {
+            translation: o.translation,
+            rotation: o.rotation,
+            scale: o.scale,
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,30 +1,21 @@
 //! Provides network-able types for common bevy types.
+//!
+//! Types:
+//!  - [Transform]
+//!  - [OrthographicProjection]
+//!  - [AmbientLight]
+//!  - [DirectionalLight]
+//!  - [PointLight]
+//!  - [Name]
+//!  - [Visibility]
+//!  - [AlphaMode]
+//!  - [EulerRot]
+//!
+//! If you think other network-able types would be helpful to many users,
+//! and think it should be included here, please send a PR.
 
-use bevy::prelude::*;
+mod light;
+mod misc;
 
-#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Debug)]
-pub struct NetTransform {
-    pub translation: Vec3,
-    pub rotation: Quat,
-    pub scale: Vec3,
-}
-
-impl From<Transform> for NetTransform {
-    fn from(o: Transform) -> Self {
-        MyTransform {
-            translation: o.translation,
-            rotation: o.rotation,
-            scale: o.scale,
-        }
-    }
-}
-
-impl From<NetTransform> for Transform {
-    fn from(o: MyTransform) -> Self {
-        Transform {
-            translation: o.translation,
-            rotation: o.rotation,
-            scale: o.scale,
-        }
-    }
-}
+pub use light::*;
+pub use misc::*;

--- a/todo.md
+++ b/todo.md
@@ -6,10 +6,11 @@
 - [x] Make the client and server directions different.
 - [ ] Integration with events.
 - [ ] Change detection.
-- [ ] Provide network-able versions of the common types.
+- [x] Provide network-able versions of the common types.
 - [x] Add plugin registration to doc and quickstart.
 - [x] Fix error that the console gets spammed with.
 - [x] License. 
+- [ ] Cargo deny.
 
 ## For v0.4.0:
 - [ ] RPC like system.


### PR DESCRIPTION
Tangent with carrier-pigeon adding timestamps to unreliable messages, bevy-pigeon can leverage this by keeping track of the send timestamp of the most recent component update. In English: This would make sure that we never overwrite new data with older data. This wouldn't happen often in the real world, but variability of UDP packets is certainly real. This will also allow us to select the latest message if we receive two of the same type in the same tick.
There is also some other unrelated development in this branch as I have been rather unorganized, since I am currently working on pigeon alone.