### PR TITLE
Update to Bevy 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-pigeon"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Mitchell Marino <mitchoah@gmail.com>"]
 edition = "2021"
 description = "The bevy plugin for carrier-pigeon."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ name = "mvp"
 name = "player"
 
 [dev-dependencies]
-bevy = "~0.7.0"
+bevy = "~0.8.0"
 
 [dependencies]
 carrier-pigeon = "~0.3"
-bevy = { version = "~0.7.0", default-features = false }
+bevy = { version = "~0.8.0", default-features = false }
 serde = { version = "~1.0", features = ["derive"] }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Building on `carrier-pigeon`, this crate provides high level network abstraction
 
 ### Add bevy-pigeon to your `Cargo.toml`:
 
-`bevy-pigeon = "0.3.0"`
+`bevy-pigeon = "0.4.0"`
 
 ## Compatibility
 | `bevy` | `bevy-pigeon` | `carrier-pigeon` |
 |:------:|:-------------:|:----------------:|
 |  0.7   |      0.3      |       0.3        |
+|  0.8   |      0.3      |       0.3        |
 
 ## Is bevy-pigeon right for me?
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Building on `carrier-pigeon`, this crate provides high level network abstraction
 | `bevy` | `bevy-pigeon` | `carrier-pigeon` |
 |:------:|:-------------:|:----------------:|
 |  0.7   |      0.3      |       0.3        |
-|  0.8   |      0.3      |       0.3        |
+|  0.8   |      0.4      |       0.4        |
 
 ## Is bevy-pigeon right for me?
 

--- a/examples/mvp.rs
+++ b/examples/mvp.rs
@@ -74,7 +74,7 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // Camera
-    commands.spawn_bundle(PerspectiveCameraBundle {
+    commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });

--- a/examples/player.rs
+++ b/examples/player.rs
@@ -73,13 +73,19 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     // Camera
-    commands.spawn_bundle(PerspectiveCameraBundle {
+    commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 10.0, 10.0).looking_at(Vec3::default(), Vec3::Y),
-        ..PerspectiveCameraBundle::new_3d()
+        ..Camera3dBundle::default()
+    })
+    .insert(UiCameraConfig {
+        show_ui: true
     });
 
-    // UI Camera
-    commands.spawn_bundle(UiCameraBundle::default());
+
+    commands.spawn_bundle(PointLightBundle {
+        transform: Transform::from_xyz(0.0, 10.0, 0.0),
+        ..default()
+    });
 }
 
 /// A generic clean up system.
@@ -170,7 +176,7 @@ mod menu {
         };
         let button_style = Style {
             size: Size::new(Val::Px(1000.0), Val::Px(100.0)),
-            margin: Rect::all(Val::Px(20.0)),
+            margin: UiRect::all(Val::Px(20.0)),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
             ..default()
@@ -180,8 +186,8 @@ mod menu {
             .spawn_bundle(NodeBundle {
                 style: Style {
                     position_type: PositionType::Absolute,
-                    margin: Rect::all(Val::Auto),
-                    padding: Rect::all(Val::Px(10.0)),
+                    margin: UiRect::all(Val::Auto),
+                    padding: UiRect::all(Val::Px(10.0)),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
                     align_self: AlignSelf::Center,
@@ -199,20 +205,19 @@ mod menu {
                 // Title
                 parent.spawn_bundle(TextBundle {
                     style: Style {
-                        margin: Rect {
+                        margin: UiRect {
                             bottom: Val::Px(0.0),
-                            ..Rect::all(Val::Px(20.0))
+                            ..UiRect::all(Val::Px(20.0))
                         },
                         ..default()
                     },
-                    text: Text::with_section(
+                    text: Text::from_section(
                         "Player Example",
                         TextStyle {
                             color: Color::WHITE,
                             font_size: 100.0,
                             ..text_style.clone()
                         },
-                        TextAlignment::default(),
                     ),
                     ..default()
                 });
@@ -227,10 +232,9 @@ mod menu {
                     .insert(MenuButton::Server)
                     .with_children(|parent| {
                         parent.spawn_bundle(TextBundle {
-                            text: Text::with_section(
+                            text: Text::from_section(
                                 "Start Server",
                                 text_style.clone(),
-                                TextAlignment::default(),
                             ),
                             ..Default::default()
                         });
@@ -246,10 +250,9 @@ mod menu {
                     .insert(MenuButton::Host)
                     .with_children(|parent| {
                         parent.spawn_bundle(TextBundle {
-                            text: Text::with_section(
+                            text: Text::from_section(
                                 "Start Host",
                                 text_style.clone(),
-                                TextAlignment::default(),
                             ),
                             ..Default::default()
                         });
@@ -265,10 +268,9 @@ mod menu {
                     .insert(MenuButton::Client)
                     .with_children(|parent| {
                         parent.spawn_bundle(TextBundle {
-                            text: Text::with_section(
+                            text: Text::from_section(
                                 "Start Client",
                                 text_style,
-                                TextAlignment::default(),
                             ),
                             ..Default::default()
                         });
@@ -346,8 +348,8 @@ mod connecting {
             .spawn_bundle(NodeBundle {
                 style: Style {
                     position_type: PositionType::Absolute,
-                    margin: Rect::all(Val::Auto),
-                    padding: Rect::all(Val::Px(10.0)),
+                    margin: UiRect::all(Val::Auto),
+                    padding: UiRect::all(Val::Px(10.0)),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
                     align_self: AlignSelf::Center,
@@ -364,13 +366,15 @@ mod connecting {
             .with_children(|parent| {
                 parent.spawn_bundle(TextBundle {
                     style: Style {
-                        margin: Rect {
+                        margin: UiRect {
                             bottom: Val::Px(0.0),
-                            ..Rect::all(Val::Px(20.0))
+                            top: Val::Px(20.0),
+                            left: Val::Px(20.0),
+                            right: Val::Px(20.0),
                         },
                         ..default()
                     },
-                    text: Text::with_section("Connecting...", text_style, TextAlignment::default()),
+                    text: Text::from_section("Connecting...", text_style),
                     ..default()
                 });
             });

--- a/examples/player.rs
+++ b/examples/player.rs
@@ -368,9 +368,7 @@ mod connecting {
                     style: Style {
                         margin: UiRect {
                             bottom: Val::Px(0.0),
-                            top: Val::Px(20.0),
-                            left: Val::Px(20.0),
-                            right: Val::Px(20.0),
+                            ..UiRect::all(Val::Px(20.0))
                         },
                         ..default()
                     },


### PR DESCRIPTION
Updating from bevy 0.7.0 to bevy 0.8.0, there were only a few differences, and they were all in the examples:

- Cameras changed from `PerspectiveCameraBundle` and `UiCameraBundle` to just `Camera3dBundle` with a `UiCameraConfig` since they are now combined in 0.8.0
- `Text::with_sections` became `Text::from_sections` and the alignment disappeared


Apart from that, I added a point light to the `player` example for better visibility. 